### PR TITLE
v1.2.17 rc

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,7 +2,7 @@ name: Release to deploy repo
 on:
   push:
     branches:
-      - fix-docker-error
+      - master
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -30,7 +30,8 @@ jobs:
         git config --global user.email 'noreply@chiefonboarding.com'
         git add -A 
         git commit -m "Deploy" 
-        git push -f origin master:deploy-beta
+        git status
+        git push -f origin master:deploy
     - name: Login to DockerHub
       uses: docker/login-action@v1 
       with:
@@ -40,9 +41,8 @@ jobs:
       id: docker_build
       uses: docker/build-push-action@v2
       with:
-        context: https://github.com/chiefonboarding/ChiefOnboarding.git#deploy-beta
+        context: https://github.com/chiefonboarding/ChiefOnboarding.git#deploy
         file: ./back/Dockerfile
         push: true
         tags: |
-          chiefonboarding/chiefonboarding-beta:latest
-          chiefonboarding/chiefonboarding-beta:1.2.17
+          chiefonboarding/chiefonboarding:1.2.17-rc1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,7 +2,7 @@ name: Release to deploy repo
 on:
   push:
     branches:
-      - master 
+      - fix-docker-error
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -30,8 +30,7 @@ jobs:
         git config --global user.email 'noreply@chiefonboarding.com'
         git add -A 
         git commit -m "Deploy" 
-        git status
-        git push -f origin master:deploy
+        git push -f origin master:deploy-beta
     - name: Login to DockerHub
       uses: docker/login-action@v1 
       with:
@@ -41,9 +40,9 @@ jobs:
       id: docker_build
       uses: docker/build-push-action@v2
       with:
-        context: https://github.com/chiefonboarding/ChiefOnboarding.git#deploy
+        context: https://github.com/chiefonboarding/ChiefOnboarding.git#deploy-beta
         file: ./back/Dockerfile
         push: true
         tags: |
-          chiefonboarding/chiefonboarding:latest
-          chiefonboarding/chiefonboarding:1.2.16
+          chiefonboarding/chiefonboarding-beta:latest
+          chiefonboarding/chiefonboarding-beta:1.2.17

--- a/back/Dockerfile
+++ b/back/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:latest
+FROM python:3.7
 RUN apt-get update
 RUN mkdir /var/run/supervisord
 RUN mkdir /var/log/supervisord


### PR DESCRIPTION
- Forcing Python 3.7 to avoid SemLock error on DO/Render 

Since this is a release candidate, I am not pushing this to latest just yet.