### PR TITLE
Fix: sequence duplication

### DIFF
--- a/back/admin/resources/models.py
+++ b/back/admin/resources/models.py
@@ -78,10 +78,11 @@ class Resource(BaseItem):
     def notification_add_type(self):
         return "added_resource"
 
-    def duplicate(self):
+    def duplicate(self, change_name=True):
         old_resource = Resource.objects.get(pk=self.pk)
         self.pk = None
-        self.name = _("%(name)s (duplicate)") % {"name": self.name}
+        if change_name:
+            self.name = _("%(name)s (duplicate)") % {"name": self.name}
         self.save()
 
         # old vs new ids for referencing parent_chapters

--- a/back/admin/sequences/models.py
+++ b/back/admin/sequences/models.py
@@ -189,7 +189,7 @@ class ExternalMessage(ContentMixin, models.Model):
         if self.is_text_message:
             return render_to_string("_text_icon.html")
 
-    def duplicate(self):
+    def duplicate(self, change_name=False):
         self.pk = None
         self.save()
         return self
@@ -368,7 +368,7 @@ class PendingAdminTask(models.Model):
     def get_icon_template(self):
         return render_to_string("_admin_task_icon.html")
 
-    def duplicate(self):
+    def duplicate(self, change_name=False):
         self.pk = None
         self.save()
         return self
@@ -386,7 +386,7 @@ class IntegrationConfig(models.Model):
     def get_icon_template(self):
         return render_to_string("_integration_config.html")
 
-    def duplicate(self):
+    def duplicate(self, change_name=False):
         self.pk = None
         self.save()
         return self
@@ -515,24 +515,27 @@ class Condition(models.Model):
                 "integration_configs",
             ]:
                 # Duplicate old ones
+                items = []
                 old_custom_templates = getattr(old_condition, field.name).filter(
                     template=False
                 )
                 for old in old_custom_templates:
-                    dup = old.duplicate()
-                    getattr(self, field.name).add(dup)
+                    dup = old.duplicate(change_name=False)
+                    items.append(dup)
 
                 # Only using set() for template items. The other ones need to be
                 # duplicated as they are unique to the condition
                 old_templates = getattr(old_condition, field.name).filter(template=True)
-                getattr(self, field.name).set(old_templates)
+                getattr(self, field.name).add(*old_templates, *items)
 
             else:
                 # For items that do not have templates, just duplicate them
+                items = []
                 old_custom_templates = getattr(old_condition, field.name).all()
                 for old in old_custom_templates:
-                    dup = old.duplicate()
-                    getattr(self, field.name).add(dup)
+                    dup = old.duplicate(change_name=False)
+                    items.append(dup)
+                getattr(self, field.name).add(*items)
 
         # returning the new item
         return self

--- a/back/admin/sequences/models.py
+++ b/back/admin/sequences/models.py
@@ -36,6 +36,7 @@ class Sequence(models.Model):
     def __str__(self):
         return self.name
 
+    @property
     def update_url(self):
         return reverse("sequences:update", args=[self.id])
 

--- a/back/admin/sequences/templates/sequence.html
+++ b/back/admin/sequences/templates/sequence.html
@@ -4,7 +4,7 @@
 
 {% block actions %}
 {% if object %}
-<form method="POST" action="{% url 'templates:duplicate' object.class_name object.id %}">
+<form method="POST" action="{% url 'templates:duplicate_seq' object.id %}">
   {% csrf_token %}
   <button type="submit" class="btn btn-primary">
     {% translate "Duplicate" %}

--- a/back/admin/sequences/tests.py
+++ b/back/admin/sequences/tests.py
@@ -78,7 +78,7 @@ def test_sequence_create_view(client, admin_factory):
     sequence = Sequence.objects.first()
     # Check that condition without actual condition was created
     assert sequence.conditions.all().first().condition_type == 3
-    assert sequence.update_url() == reverse("sequences:update", args=[sequence.id])
+    assert sequence.update_url == reverse("sequences:update", args=[sequence.id])
     assert sequence.class_name() == "Sequence"
     assert response.redirect_chain[-1][0] == reverse(
         "sequences:update", args=[sequence.id]

--- a/back/admin/sequences/views.py
+++ b/back/admin/sequences/views.py
@@ -54,7 +54,7 @@ class SequenceCreateView(LoginRequiredMixin, ManagerPermMixin, RedirectView):
     def get_redirect_url(self, *args, **kwargs):
         seq = Sequence.objects.create(name="New sequence")
         seq.conditions.create(condition_type=3)
-        return seq.update_url()
+        return seq.update_url
 
 
 class SequenceView(LoginRequiredMixin, ManagerPermMixin, DetailView):

--- a/back/admin/templates/tests.py
+++ b/back/admin/templates/tests.py
@@ -7,6 +7,7 @@ from admin.badges.factories import BadgeFactory  # noqa
 from admin.introductions.factories import IntroductionFactory  # noqa
 from admin.preboarding.factories import PreboardingFactory  # noqa
 from admin.resources.factories import ResourceFactory  # noqa
+from admin.sequences.models import Sequence  # noqa
 from admin.to_do.factories import ToDoFactory  # noqa
 
 
@@ -93,3 +94,28 @@ def test_templates_crud(
     assert "(duplicate)" in response.content.decode()
     assert object_model.templates.all().count() == 1
     assert "item has been removed" in response.content.decode()
+
+
+@pytest.mark.django_db
+def test_sequence_duplicate(
+    client, django_user_model, sequence_factory, condition_with_items_factory
+):
+    # Force admin to login
+    client.force_login(django_user_model.objects.create(role=1))
+
+    # Get list view of template
+    url = reverse("sequences:list")
+    response = client.get(url)
+    assert "No items available" in response.content.decode()
+
+    seq = sequence_factory()
+    condition_with_items_factory(sequence=seq)
+
+    url = reverse("sequences:list")
+    response = client.get(url)
+    assert "No items available" not in response.content.decode()
+
+    url = reverse("templates:duplicate_seq", args=[seq.id])
+    response = client.post(url)
+
+    assert Sequence.objects.all().count() == 2

--- a/back/admin/templates/urls.py
+++ b/back/admin/templates/urls.py
@@ -9,4 +9,9 @@ urlpatterns = [
         views.TemplateDuplicateView.as_view(),
         name="duplicate",
     ),
+    path(
+        "duplicate_seq/<int:template_pk>/",
+        views.SequenceDuplicateView.as_view(),
+        name="duplicate_seq",
+    ),
 ]

--- a/back/admin/templates/views.py
+++ b/back/admin/templates/views.py
@@ -2,12 +2,21 @@ from django.shortcuts import get_object_or_404, redirect
 from django.views.generic import View
 
 from admin.templates.utils import get_templates_model
-from users.mixins import AdminPermMixin, LoginRequiredMixin
+from admin.sequences.models import Sequence
+from users.mixins import ManagerPermMixin, LoginRequiredMixin
 
 
-class TemplateDuplicateView(LoginRequiredMixin, AdminPermMixin, View):
+class TemplateDuplicateView(LoginRequiredMixin, ManagerPermMixin, View):
     def post(self, request, template_pk, template_type, *args, **kwargs):
         templates_model = get_templates_model(template_type)
         template_item = get_object_or_404(templates_model, id=template_pk)
         new_template_item = template_item.duplicate()
+        return redirect(new_template_item.update_url)
+
+
+class SequenceDuplicateView(LoginRequiredMixin, ManagerPermMixin, View):
+    def post(self, request, template_pk, *args, **kwargs):
+        template_item = get_object_or_404(Sequence, id=template_pk)
+        new_template_item = template_item.duplicate()
+        print(new_template_item)
         return redirect(new_template_item.update_url)

--- a/back/organization/models.py
+++ b/back/organization/models.py
@@ -227,9 +227,10 @@ class BaseItem(ContentMixin, models.Model):
     def class_name(self):
         return self.__class__.__name__
 
-    def duplicate(self):
+    def duplicate(self, change_name=True):
         self.pk = None
-        self.name = _("%(name)s (duplicate)") % {"name": self.name}
+        if change_name:
+            self.name = _("%(name)s (duplicate)") % {"name": self.name}
         self.save()
         return self
 

--- a/back/slack_bot/tests.py
+++ b/back/slack_bot/tests.py
@@ -131,8 +131,12 @@ def test_slack_show_resources_items_in_category_no_category(
 ):
     new_hire = new_hire_factory(slack_user_id="slackx")
 
-    resource_user1 = resource_user_factory(resource__category=None, user=new_hire)
-    resource_user2 = resource_user_factory(resource__category=None, user=new_hire)
+    resource_user1 = resource_user_factory(
+        resource__category=None, user=new_hire, resource__name="1test"
+    )
+    resource_user2 = resource_user_factory(
+        resource__category=None, user=new_hire, resource__name="2test"
+    )
 
     ResourceUserFactory(user=new_hire)
 

--- a/back/slack_bot/views.py
+++ b/back/slack_bot/views.py
@@ -453,7 +453,7 @@ def slack_show_resources_items_in_category(payload, body):
         paragraph(_("Here are your options:")),
         *[
             SlackResource(resource_user, user).get_block()
-            for resource_user in resources
+            for resource_user in resources.order_by("resource__name")
         ],
     ]
 


### PR DESCRIPTION
- Server returned a 500 error when duplicating. This has been fixed.
- Some minor speed improvements. 
- Avoided name change when duplicating (normally it would add "(duplicate)")
- Fix randomly failing slack test (ordering issue)