### PR TITLE
Remove preboarding send menu option

### DIFF
--- a/back/admin/integrations/models.py
+++ b/back/admin/integrations/models.py
@@ -74,7 +74,11 @@ class Integration(models.Model):
         else:
             post_data = {}
         return requests.request(
-            data["method"], url, headers=self._headers, data=post_data, timeout=120
+            data.get("method", "POST"),
+            url,
+            headers=self._headers,
+            data=post_data,
+            timeout=120,
         ).json()
 
     def _replace_vars(self, text):

--- a/back/admin/people/templates/_new_hire_settings_menu.html
+++ b/back/admin/people/templates/_new_hire_settings_menu.html
@@ -4,7 +4,9 @@
     {% translate "Settings" %}
   </button>
   <div class="dropdown-menu dropdown-menu-right">
+    {% if object.workday < 1 %}
     <a class="dropdown-item" href="{% url 'people:send_preboarding_notification' object.id %}">{% translate "Send Preboarding email" %}</a>
+    {% endif %}
     <form method="post" class="mb-0" action="{% url 'people:send_login_email' object.id %}">
       <button type="submit" class="dropdown-item">{% translate "Send login email (day 1 and onwards)" %}</button>
     </form>


### PR DESCRIPTION
If user has already started then remove this option as it would show a 404 in most cases anyway. 
People could work around this (by visiting the url directly) and that's okay.

Also make POST the default for integrations (small change, shouldn't impact anything)