### PR TITLE
Fix sending preboarding email, first day email and use custom email

### DIFF
--- a/back/admin/people/new_hire_views.py
+++ b/back/admin/people/new_hire_views.py
@@ -163,7 +163,7 @@ class NewHireSendPreboardingNotificationView(
     def form_valid(self, form):
         new_hire = get_object_or_404(get_user_model(), id=self.kwargs.get("pk", -1))
         if form.cleaned_data["send_type"] == "email":
-            send_new_hire_preboarding(new_hire)
+            send_new_hire_preboarding(new_hire, form.cleaned_data["email"])
         else:
             client = Client(settings.TWILIO_ACCOUNT_SID, settings.TWILIO_AUTH_TOKEN)
             client.messages.create(

--- a/back/admin/people/templates/_new_hire_settings_menu.html
+++ b/back/admin/people/templates/_new_hire_settings_menu.html
@@ -8,6 +8,7 @@
     <a class="dropdown-item" href="{% url 'people:send_preboarding_notification' object.id %}">{% translate "Send Preboarding email" %}</a>
     {% endif %}
     <form method="post" class="mb-0" action="{% url 'people:send_login_email' object.id %}">
+      {% csrf_token %}
       <button type="submit" class="dropdown-item">{% translate "Send login email (day 1 and onwards)" %}</button>
     </form>
     <a class="dropdown-item" href="{% url 'people:add_sequence' object.id %}">{% translate "Add Sequence" %}</a>

--- a/back/admin/people/templates/trigger_preboarding_notification.html
+++ b/back/admin/people/templates/trigger_preboarding_notification.html
@@ -18,3 +18,14 @@
   </div>
 </div>
 {% endblock %}
+{% block extra_js %}
+<script>
+$("select#id_send_type").on('change', function() {
+  if ($(this).val() == 'text'){
+    $("#div_id_email").addClass("d-none")
+  } else {
+    $("#div_id_email").removeClass("d-none")
+  }
+})
+</script>
+{% endblock %}

--- a/back/admin/people/tests.py
+++ b/back/admin/people/tests.py
@@ -430,14 +430,21 @@ def test_send_preboarding_message_via_email(
     assert "Send via text" not in response.content.decode()
     assert "Send via email" in response.content.decode()
 
+    # missing email address
     response = client.post(url, data={"send_type": "email"}, follow=True)
+
+    assert response.status_code == 200
+    assert "This field is required" in response.content.decode()
+
+    # missing email address
+    response = client.post(url, data={"send_type": "email", "email": "hello@chiefonboarding.com"}, follow=True)
 
     assert response.status_code == 200
     assert len(mailoutbox) == 1
     assert mailoutbox[0].subject == f"Welcome to {org.name}!"
     assert new_hire1.first_name in mailoutbox[0].alternatives[0][0]
     assert len(mailoutbox[0].to) == 1
-    assert mailoutbox[0].to[0] == new_hire1.email
+    assert mailoutbox[0].to[0] == "hello@chiefonboarding.com"
     assert (
         settings.BASE_URL
         + reverse("new_hire:preboarding-url")

--- a/back/admin/people/tests.py
+++ b/back/admin/people/tests.py
@@ -437,7 +437,11 @@ def test_send_preboarding_message_via_email(
     assert "This field is required" in response.content.decode()
 
     # missing email address
-    response = client.post(url, data={"send_type": "email", "email": "hello@chiefonboarding.com"}, follow=True)
+    response = client.post(
+        url,
+        data={"send_type": "email", "email": "hello@chiefonboarding.com"},
+        follow=True,
+    )
 
     assert response.status_code == 200
     assert len(mailoutbox) == 1

--- a/back/users/emails.py
+++ b/back/users/emails.py
@@ -163,7 +163,7 @@ def send_new_hire_credentials(new_hire_id):
     )
 
 
-def send_new_hire_preboarding(new_hire):
+def send_new_hire_preboarding(new_hire, email):
     org = Organization.object.get()
     translation.activate(new_hire.language)
     message = WelcomeMessage.objects.get(
@@ -189,7 +189,7 @@ def send_new_hire_preboarding(new_hire):
         subject=subject,
         created_for=new_hire,
         message=message,
-        to=new_hire.email,
+        to=email,
         html_message=html_message,
         notification_type="sent_email_preboarding_access",
     )


### PR DESCRIPTION
fixes #196 

- Fix not being able to send email when text messages are not set up
- Fix CSRF token missing from send first day email form
- Allow admins to enter a custom email address for preboarding email