### PR TITLE
add --access-logfile

### DIFF
--- a/back/supervisord.conf
+++ b/back/supervisord.conf
@@ -8,7 +8,7 @@ loglevel=info                ; log level; default info; others: debug,warn,trace
 user=root
 
 [program:app]
-command=bash -c "cd /app/ && python manage.py collectstatic --no-input && python manage.py createcachetable && python manage.py migrate && gunicorn --worker-tmp-dir /dev/shm back.wsgi -b 0.0.0.0:8000"
+command=bash -c "cd /app/ && python manage.py collectstatic --no-input && python manage.py createcachetable && python manage.py migrate && gunicorn --worker-tmp-dir /dev/shm --access-logfile '-' back.wsgi -b 0.0.0.0:8000"
 user=root
 
 stdout_logfile=/dev/stdout


### PR DESCRIPTION
According to Gunicorn documentation the default value of `--access-logfile` is None, so we are missing the Gunicorn's logs.
one solution is to change the `--access-logfile` value,
e.g. `--access-logfile '-' `
'-' means log to stdout.
https://docs.gunicorn.org/en/stable/settings.html#logging