### PR TITLE
Edit password/reset_change/done/ name

### DIFF
--- a/back/user_auth/urls.py
+++ b/back/user_auth/urls.py
@@ -49,7 +49,7 @@ urlpatterns = [
         PasswordResetCompleteView.as_view(
             template_name="password_change_done.html",
         ),
-        name="password_reset_done",
+        name="password_reset_complete",
     ),
     path(
         "redirect/", views.LoginRedirectView.as_view(), name="logged_in_user_redirect"


### PR DESCRIPTION
I got a 500 error after a successful reset password with the error below:
```django.urls.exceptions.NoReverseMatch: Reverse for 'password_reset_complete' not found. 'password_reset_complete' is not a valid view function or pattern name.```
I did a little bit of research about what happened to me, and I got to this, the name for the `PasswordResetCompleteView ` path should be `password_reset_complete ` instead of `password_reset_done`.
https://docs.djangoproject.com/en/4.0/topics/auth/default/#django.contrib.auth.views.PasswordResetCompleteView