### PR TITLE
_replace_vars function

### DIFF
--- a/back/admin/integrations/models.py
+++ b/back/admin/integrations/models.py
@@ -84,7 +84,8 @@ class Integration(models.Model):
     def _replace_vars(self, text):
         params = {} if not hasattr(self, "params") else self.params
         if hasattr(self, "new_hire") and self.new_hire is not None:
-            text = self.new_hire.personalize(text, self.extra_args)
+            text = self.new_hire.personalize(text, self.extra_args | params)
+            return text
         t = Template(text)
         context = Context(self.extra_args | params)
         text = t.render(context)


### PR DESCRIPTION
This is kind of hard to explain but there is a bug in the `_replace_vars` function that will delete an unknown tag, at line 87 when `new_hire.personalize` function calls.
e.g. we have a `TEAM_ID` that we want to read from a web portal (just like the `manifest.json` in the docs), the `TEAM_ID` has saved in params but the new_hire.personalize will delete the `{{TEAM_ID}}` after that there is no `{{TEAM_ID}}`.
What I did is that I put the `params` alongside the `extra_args` in the `personalize`.