### PR TITLE
Speed up notifications list and fix slack resources dialog

### DIFF
--- a/back/organization/views.py
+++ b/back/organization/views.py
@@ -69,7 +69,7 @@ class FileView(APIView):
 
 class NotificationListView(LoginRequiredMixin, AdminPermMixin, ListView):
     template_name = "notifications.html"
-    queryset = Notification.objects.all()
+    queryset = Notification.objects.all().select_related("created_by", "created_for")
     paginate_by = 40
 
     def get_context_data(self, **kwargs):

--- a/back/slack_bot/slack_resource.py
+++ b/back/slack_bot/slack_resource.py
@@ -89,7 +89,13 @@ class SlackResource:
             "private_metadata": json.dumps(private_metadata),
         }
 
-        if self.resource_user.resource.chapters.count() > 1:
+        if (
+            self.resource_user.is_course
+            and self.resource_user.resource.chapters.count() > 1
+        ) or (
+            not self.resource_user.course
+            and self.resource_user.resource.chapters.filter(type=0).count() > 1
+        ):
             modal["submit"] = {"type": "plain_text", "text": _("Next")}
 
         return modal

--- a/back/slack_bot/slack_resource.py
+++ b/back/slack_bot/slack_resource.py
@@ -92,9 +92,6 @@ class SlackResource:
         if (
             self.resource_user.is_course
             and self.resource_user.resource.chapters.count() > 1
-        ) or (
-            not self.resource_user.is_course
-            and self.resource_user.resource.chapters.filter(type=0).count() > 1
         ):
             modal["submit"] = {"type": "plain_text", "text": _("Next")}
 

--- a/back/slack_bot/slack_resource.py
+++ b/back/slack_bot/slack_resource.py
@@ -93,7 +93,7 @@ class SlackResource:
             self.resource_user.is_course
             and self.resource_user.resource.chapters.count() > 1
         ) or (
-            not self.resource_user.course
+            not self.resource_user.is_course
             and self.resource_user.resource.chapters.filter(type=0).count() > 1
         ):
             modal["submit"] = {"type": "plain_text", "text": _("Next")}

--- a/back/slack_bot/tests.py
+++ b/back/slack_bot/tests.py
@@ -600,7 +600,7 @@ def test_slack_to_do_complete_external_form(new_hire_factory, to_do_user_factory
 def test_open_resource_dialog(new_hire_factory, resource_user_factory):
     new_hire = new_hire_factory(slack_user_id="slackx")
 
-    # Should reset steps back to one
+    # Should not reset steps back to one, if it's not a course
     # Resource has questions and a page. Questions should be ignored. So not showing
     # menu.
     resource_user1 = resource_user_factory(user=new_hire, step=5)
@@ -712,12 +712,11 @@ def test_open_resource_dialog(new_hire_factory, resource_user_factory):
         + ', "resource_user": '
         + str(resource_user1.id)
         + "}",
-        "submit": {"type": "plain_text", "text": "Next"},
     }
 
     resource_user1.refresh_from_db()
 
-    assert resource_user1.step == 0
+    assert resource_user1.step == 5
 
 
 @pytest.mark.django_db

--- a/back/slack_bot/views.py
+++ b/back/slack_bot/views.py
@@ -478,8 +478,9 @@ def slack_open_resource_dialog(payload, body):
         user=user,
         id=int(payload["action_id"].split(":")[2]),
     )
-    resource_user.step = 0
-    resource_user.save()
+    if resource_user.is_course:
+        resource_user.step = 0
+        resource_user.save()
 
     view = SlackResource(resource_user=resource_user, user=user).modal_view(
         resource_user.resource.first_chapter_id


### PR DESCRIPTION
- Speed up notifications list with `select_related`
- When resource has one page item and one question, it would still show the "next" button when the course was completed. It will now show "close" instead.
- When a course was completed and a user clicked on the button again, it would reset the steps, which would mess up the status bar in the admin panel.