### PR TITLE
Feat: Fetch more slack channels

### DIFF
--- a/back/slack_bot/utils.py
+++ b/back/slack_bot/utils.py
@@ -34,6 +34,7 @@ class Slack:
                 data={
                     "exclude_archived": True,
                     "types": "public_channel,private_channel",
+                    "limit": 1000,
                 },
             )
         except Exception:


### PR DESCRIPTION
This sets the limit from `100` to `1000`. If there are more than 1000 channels, then we would need to set up pagination.