### PR TITLE
Fix: short S3 url valid time

### DIFF
--- a/back/misc/s3.py
+++ b/back/misc/s3.py
@@ -21,7 +21,7 @@ class S3:
             Params={"Bucket": settings.AWS_STORAGE_BUCKET_NAME, "Key": key},
         )
 
-    def get_file(self, key, time=3600):
+    def get_file(self, key, time=604799):
         # If a user uploads some files and then removes the keys, this would error
         # Therefore the quick check here
         if settings.AWS_ACCESS_KEY_ID == "":


### PR DESCRIPTION
URLs are now valid for almost 7 days instead of 1 hour. This could cause issues in Slack, since messages aren't updated and links would just expire. 7 days is still not ideal, but that's the max of presigned urls.