### PR TITLE
Allow authentication with AWS profile for file down/upload

### DIFF
--- a/back/back/templatetags/settings_values.py
+++ b/back/back/templatetags/settings_values.py
@@ -9,7 +9,7 @@ register = template.Library()
 # settings value
 @register.simple_tag
 def aws_enabled():
-    return settings.AWS_ACCESS_KEY_ID != ""
+    return settings.AWS_STORAGE_BUCKET_NAME != ""
 
 
 @register.simple_tag

--- a/back/back/templatetags/settings_values.py
+++ b/back/back/templatetags/settings_values.py
@@ -2,6 +2,7 @@
 import boto3
 
 from django import template
+from django.core.cache import cache
 from django.conf import settings
 from botocore.config import Config
 
@@ -14,6 +15,9 @@ def aws_enabled():
     if settings.AWS_STORAGE_BUCKET_NAME == "":
         return False
 
+    if cache.get("aws_checked"):
+        return True
+
     # Try if we can make a connection
     try:
         boto3.client(
@@ -22,6 +26,7 @@ def aws_enabled():
             endpoint_url=settings.AWS_S3_ENDPOINT_URL,
             config=Config(signature_version="s3v4"),
         ).head_bucket(Bucket=settings.AWS_STORAGE_BUCKET_NAME)
+        cache.set("aws_checked", True, timeout=None)
         return True
     except Exception:
         return False

--- a/back/misc/s3.py
+++ b/back/misc/s3.py
@@ -9,8 +9,6 @@ class S3:
             "s3",
             settings.AWS_REGION,
             endpoint_url=settings.AWS_S3_ENDPOINT_URL,
-            aws_access_key_id=settings.AWS_ACCESS_KEY_ID,
-            aws_secret_access_key=settings.AWS_SECRET_ACCESS_KEY,
             config=Config(signature_version="s3v4"),
         )
 
@@ -24,7 +22,7 @@ class S3:
     def get_file(self, key, time=604799):
         # If a user uploads some files and then removes the keys, this would error
         # Therefore the quick check here
-        if settings.AWS_ACCESS_KEY_ID == "":
+        if settings.AWS_STORAGE_BUCKET_NAME == "":
             return ""
 
         return self.client.generate_presigned_url(

--- a/back/misc/s3.py
+++ b/back/misc/s3.py
@@ -1,6 +1,5 @@
 import boto3
 from botocore.config import Config
-from botocore.exceptions import NoCredentialsError
 from django.conf import settings
 
 

--- a/back/misc/s3.py
+++ b/back/misc/s3.py
@@ -1,5 +1,6 @@
 import boto3
 from botocore.config import Config
+from botocore.exceptions import NoCredentialsError
 from django.conf import settings
 
 
@@ -25,11 +26,15 @@ class S3:
         if settings.AWS_STORAGE_BUCKET_NAME == "":
             return ""
 
-        return self.client.generate_presigned_url(
-            ClientMethod="get_object",
-            ExpiresIn=time,
-            Params={"Bucket": settings.AWS_STORAGE_BUCKET_NAME, "Key": key},
-        )
+        try:
+            return self.client.generate_presigned_url(
+                ClientMethod="get_object",
+                ExpiresIn=time,
+                Params={"Bucket": settings.AWS_STORAGE_BUCKET_NAME, "Key": key},
+            )
+        except NoCredentialsError:
+            print("Credentials are not set or incorrect")
+            return ""
 
     def delete_file(self, key):
         return self.client.delete_object(

--- a/back/misc/s3.py
+++ b/back/misc/s3.py
@@ -32,7 +32,7 @@ class S3:
                 ExpiresIn=time,
                 Params={"Bucket": settings.AWS_STORAGE_BUCKET_NAME, "Key": key},
             )
-        except NoCredentialsError:
+        except Exception:
             print("Credentials are not set or incorrect")
             return ""
 

--- a/back/organization/tests.py
+++ b/back/organization/tests.py
@@ -88,9 +88,14 @@ def test_use_custom_email_template(new_hire_factory):
 
 
 @pytest.mark.django_db
-def test_cache_logo_url(settings, file_factory):
+def test_cache_logo_url(settings, file_factory, monkeypatch):
+
     settings.AWS_ACCESS_KEY_ID = "xxx"
     settings.AWS_STORAGE_BUCKET_NAME = "xxx"
+
+    monkeypatch.setenv("AWS_STORAGE_BUCKET_NAME", "test")
+    monkeypatch.setenv("AWS_ACCESS_KEY_ID", "test")
+    monkeypatch.setenv("AWS_SECRET_ACCESS_KEY", "test")
 
     file1 = file_factory()
     file2 = file_factory()
@@ -129,9 +134,12 @@ def test_cache_logo_url(settings, file_factory):
 
 
 @pytest.mark.django_db
-def test_file_url(settings, client, new_hire_factory, file_factory):
+def test_file_url(settings, client, new_hire_factory, file_factory, monkeypatch):
     settings.AWS_ACCESS_KEY_ID = "xxx"
     settings.AWS_STORAGE_BUCKET_NAME = "xxx"
+    monkeypatch.setenv("AWS_STORAGE_BUCKET_NAME", "test")
+    monkeypatch.setenv("AWS_ACCESS_KEY_ID", "test")
+    monkeypatch.setenv("AWS_SECRET_ACCESS_KEY", "test")
 
     new_hire = new_hire_factory()
     file1 = file_factory()


### PR DESCRIPTION
fixes #236 

Allow boto to search for environment variables by itself (except for the region, endpoint and signature) to add the option to not use key/secret, but a profile instead.