### PR TITLE
Fix error when viewing new hire tasks as admin without startday

### DIFF
--- a/back/admin/people/tests.py
+++ b/back/admin/people/tests.py
@@ -115,6 +115,69 @@ def test_create_new_hire_with_sequences(
 
 
 @pytest.mark.django_db
+def test_create_new_hire_manager_options(
+    client,
+    django_user_model,
+    admin_factory,
+    new_hire_factory,
+    manager_factory,
+):
+    client.force_login(django_user_model.objects.create(role=1))
+
+    admin1 = admin_factory(slack_user_id="test")
+    admin2 = admin_factory()
+    manager1 = manager_factory()
+    manager2 = manager_factory()
+    new_hire1 = new_hire_factory()
+    new_hire2 = new_hire_factory(slack_user_id="test")
+
+    url = reverse("people:new_hire_add")
+    response = client.get(url)
+
+    assert admin1.full_name in response.content.decode()
+    assert admin2.full_name in response.content.decode()
+    assert manager1.full_name in response.content.decode()
+    assert manager2.full_name in response.content.decode()
+    assert new_hire2.full_name in response.content.decode()
+
+    # new hire 1 should not show up
+    assert new_hire1.full_name not in response.content.decode()
+
+
+@pytest.mark.django_db
+def test_update_new_hire_manager_options(
+    client,
+    django_user_model,
+    admin_factory,
+    new_hire_factory,
+    manager_factory,
+):
+    client.force_login(django_user_model.objects.create(role=1))
+
+    admin1 = admin_factory(slack_user_id="test")
+    admin2 = admin_factory()
+    manager1 = manager_factory()
+    manager2 = manager_factory()
+    new_hire1 = new_hire_factory()
+    new_hire2 = new_hire_factory(slack_user_id="test")
+    new_hire3 = new_hire_factory(manager=new_hire1)
+    new_hire4 = new_hire_factory()
+
+    url = reverse("people:new_hire_profile", args=[new_hire3.id])
+    response = client.get(url)
+
+    assert admin1.full_name in response.content.decode()
+    assert admin2.full_name in response.content.decode()
+    assert manager1.full_name in response.content.decode()
+    assert manager2.full_name in response.content.decode()
+    assert new_hire2.full_name in response.content.decode()
+    assert new_hire4.full_name not in response.content.decode()
+
+    # new hire 1 should not show up, but in this case they are already assigned
+    assert new_hire1.full_name in response.content.decode()
+
+
+@pytest.mark.django_db
 def test_create_new_hire_with_sequences_before_starting(
     client,
     django_user_model,

--- a/back/new_hire/templates/new_hire_base.html
+++ b/back/new_hire/templates/new_hire_base.html
@@ -109,6 +109,7 @@
             <div class="d-flex flex-column flex-md-row flex-fill align-items-stretch align-items-md-center">
               {% if 'preboarding' not in request.path %}
               <ul class="navbar-nav">
+                {% if request.user.role == 0 %}
                 <li class="nav-item {% if 'todos' in request.path %}active{% endif %}">
                   <a class="nav-link" href="{% url 'new_hire:todos' %}">
                     <span class="nav-link-icon d-md-none d-lg-inline-block"><!-- Download SVG icon from http://tabler-icons.io/i/home -->
@@ -123,6 +124,7 @@
                     </span>
                   </a>
                 </li>
+                {% endif %}
                 <li class="nav-item {% if 'resources' in request.path %}active{% endif %}">
                   <a class="nav-link" href="{% url 'new_hire:resources' %}">
                     <span class="nav-link-icon d-md-none d-lg-inline-block"><!-- Download SVG icon from http://tabler-icons.io/i/home -->

--- a/back/new_hire/tests.py
+++ b/back/new_hire/tests.py
@@ -91,6 +91,25 @@ def test_show_over_due_to_do_view(client, new_hire_factory, to_do_user_factory):
 
 
 @pytest.mark.django_db
+def test_404_to_do_view_for_admin(client, admin_factory, to_do_user_factory):
+    admin = admin_factory()
+    client.force_login(admin)
+
+    to_do_item1 = to_do_user_factory(user=admin)
+
+    url = reverse(
+        "new_hire:to_do",
+        args=[
+            to_do_item1.id,
+        ],
+    )
+
+    response = client.get(url)
+
+    assert response.status_code == 404
+
+
+@pytest.mark.django_db
 def test_to_do_item_view(client, new_hire_factory, to_do_user_factory):
     new_hire = new_hire_factory()
     client.force_login(new_hire)

--- a/back/new_hire/tests.py
+++ b/back/new_hire/tests.py
@@ -95,14 +95,9 @@ def test_404_to_do_view_for_admin(client, admin_factory, to_do_user_factory):
     admin = admin_factory()
     client.force_login(admin)
 
-    to_do_item1 = to_do_user_factory(user=admin)
+    to_do_user_factory(user=admin)
 
-    url = reverse(
-        "new_hire:to_do",
-        args=[
-            to_do_item1.id,
-        ],
-    )
+    url = reverse("new_hire:todos")
 
     response = client.get(url)
 

--- a/back/new_hire/views.py
+++ b/back/new_hire/views.py
@@ -35,6 +35,11 @@ class NewHireDashboard(LoginRequiredMixin, TemplateView):
 
     def get_context_data(self, **kwargs):
         new_hire = self.request.user
+
+        # Check that user is allowed to see page (only new hires)
+        if new_hire.role != 0:
+            raise Http404
+
         context = super().get_context_data(**kwargs)
 
         context["overdue_to_do_items"] = ToDoUser.objects.overdue(new_hire)

--- a/back/users/models.py
+++ b/back/users/models.py
@@ -52,6 +52,13 @@ class CustomUserManager(BaseUserManager):
         return self.get(**{self.model.USERNAME_FIELD + "__iexact": email})
 
 
+class ManagerSlackManager(models.Manager):
+    def get_queryset(self):
+        return super().get_queryset().filter(
+            role__in=[1, 2]
+        ) | super().get_queryset().exclude(slack_user_id="")
+
+
 class ManagerManager(models.Manager):
     def get_queryset(self):
         return super().get_queryset().filter(role__in=[1, 2])
@@ -192,6 +199,7 @@ class User(AbstractBaseUser):
 
     objects = CustomUserManager()
     managers_and_admins = ManagerManager()
+    managers_and_admins_or_slack_users = ManagerSlackManager()
     new_hires = NewHireManager()
     admins = AdminManager()
     ordering = ("first_name",)


### PR DESCRIPTION
fixes #253 

This will limit a buddy/manager to a manager/admin/slack user. We can still allow a Slack user as they have the option to check tasks off through the Slack app.

To do:
- [x] tests