### PR TITLE
Remove REST_FRAMEWORK_ACTIVE

### DIFF
--- a/back/back/settings.py
+++ b/back/back/settings.py
@@ -318,7 +318,6 @@ AUTHENTICATION_BACKENDS = [
 ]
 AXES_ENABLED = True
 AXES_FAILURE_LIMIT = 10
-REST_FRAMEWORK_ACTIVE = True
 
 # Error tracking
 if env("SENTRY_URL", default="") != "":


### PR DESCRIPTION
REST_FRAMEWORK_ACTIVE is no longer available in Django-axes. so it's better to remove it.