### PR TITLE
Fix progress bar not showing up

### DIFF
--- a/back/admin/people/templates/new_hire_progress.html
+++ b/back/admin/people/templates/new_hire_progress.html
@@ -69,8 +69,8 @@
             </td>
             <td style="width: 100px">
               <div class="progress">
-                <div class="progress-bar" style="width: {{resource.percentage_completed}}%" role="progressbar" aria-valuenow="{{resource.percentage_completed}}" aria-valuemin="0" aria-valuemax="100">
-                  <span class="visually-hidden">{{ resource.percentage_completed }}% {% translate "Complete" %}</span>
+                <div class="progress-bar" style="width: {{resource.percentage_completed|floatformat:"0" }}%" role="progressbar" aria-valuenow="{{resource.percentage_completed|floatformat:"0" }}" aria-valuemin="0" aria-valuemax="100">
+                  <span class="visually-hidden">{{ resource.percentage_completed|floatformat:"0" }}% {% translate "Complete" %}</span>
                 </div>
               </div>
             </td>

--- a/back/admin/people/templates/new_hires.html
+++ b/back/admin/people/templates/new_hires.html
@@ -29,7 +29,7 @@
             </td>
             <td>
               <div class="progress mb-2">
-                <div class="progress-bar" style="width: {{new_hire.progress}}%" role="progressbar" aria-valuenow="{{ new_hire.completed_tasks }}" aria-valuemin="0" aria-valuemax="{{ new_hire.total_tasks }}">
+                <div class="progress-bar" style="width: {{new_hire.progress|floatformat:"0" }}%" role="progressbar" aria-valuenow="{{ new_hire.completed_tasks }}" aria-valuemin="0" aria-valuemax="{{ new_hire.total_tasks }}">
                 </div>
               </div>
             </td>

--- a/back/new_hire/templates/new_hire_resource_detail.html
+++ b/back/new_hire/templates/new_hire_resource_detail.html
@@ -17,8 +17,8 @@
           {% if object.course and not resource_user.completed_course %}
           <div class="col-4">
             <div class="progress" style="margin-top:11px !important">
-              <div class="progress-bar" style="width: {{resource_user.percentage_completed}}%" role="progressbar" aria-valuenow="{{resource_user.percentage_completed}}" aria-valuemin="0" aria-valuemax="100">
-                <span class="visually-hidden">{{ resource_user.percentage_completed }}% {% translate "Complete" %}</span>
+              <div class="progress-bar" style="width: {{resource_user.percentage_completed|floatformat:"0" }}%" role="progressbar" aria-valuenow="{{resource_user.percentage_completed|floatformat:"0" }}" aria-valuemin="0" aria-valuemax="100">
+                <span class="visually-hidden">{{ resource_user.percentage_completed|floatformat:"0" }}% {% translate "Complete" %}</span>
               </div>
             </div>
           </div>


### PR DESCRIPTION
Fixes #299 

The progress bar didn't show up if the locale changed. 66.66% would turn to 66,66% and that doesn't work in HTML/CSS. It is now rounded to a full number as the decimals aren't important anyway.