### PR TITLE
Add error to failed integration

### DIFF
--- a/back/admin/integrations/models.py
+++ b/back/admin/integrations/models.py
@@ -255,7 +255,7 @@ class Integration(models.Model):
                     # Only errors when item gets added another time, so we can safely
                     # let it pass.
                     pass
-                return (False, response)
+                return False, response
 
         # Run all post requests (notifications)
         for item in self.manifest.get("post_execute_notification", []):

--- a/back/admin/integrations/tests.py
+++ b/back/admin/integrations/tests.py
@@ -379,14 +379,7 @@ def test_integration_oauth_callback_view(
 
 
 @pytest.mark.django_db
-@patch(
-    "admin.integrations.models.Integration.run_request",
-    Mock(return_value=(True, Mock(json=lambda: {"access_token": "test"}))),
-)
-def test_integration_clean_error_data(
-    client, django_user_model, custom_integration_factory
-):
-    client.force_login(django_user_model.objects.create(role=1))
+def test_integration_clean_error_data(custom_integration_factory):
     integration = custom_integration_factory(
         extra_args={
             "SECRET_KEY": "123",

--- a/back/admin/integrations/tests.py
+++ b/back/admin/integrations/tests.py
@@ -379,6 +379,26 @@ def test_integration_oauth_callback_view(
 
 
 @pytest.mark.django_db
+@patch(
+    "admin.integrations.models.Integration.run_request",
+    Mock(return_value=(True, Mock(json=lambda: {"access_token": "test"}))),
+)
+def test_integration_clean_error_data(
+    client, django_user_model, custom_integration_factory
+):
+    client.force_login(django_user_model.objects.create(role=1))
+    integration = custom_integration_factory(
+        extra_args={
+            "SECRET_KEY": "123",
+        }
+    )
+    assert (
+        integration.clean_response("test 123 error")
+        == "test ***Secret value for SECRET_KEY*** error"
+    )
+
+
+@pytest.mark.django_db
 # Returns text instead of request object
 @patch(
     "admin.integrations.models.Integration.run_request",

--- a/back/admin/people/new_hire_views.py
+++ b/back/admin/people/new_hire_views.py
@@ -693,7 +693,7 @@ class NewHireGiveAccessView(
             new_hire.extra_fields |= user_details_form.cleaned_data
             new_hire.save()
 
-            success = integration.execute(
+            success, error = integration.execute(
                 new_hire, integration_config_form.cleaned_data
             )
 
@@ -701,6 +701,7 @@ class NewHireGiveAccessView(
                 messages.success(request, _("Account has been created"))
             else:
                 messages.error(request, _("Account could not be created"))
+                messages.error(request, error)
 
             return redirect("people:new_hire_access", pk=new_hire.id)
 

--- a/back/admin/people/tests.py
+++ b/back/admin/people/tests.py
@@ -1617,7 +1617,8 @@ def test_new_hire_access_per_integration_post(
     assert "This field is required" in response.content.decode()
 
     with patch(
-        "admin.integrations.models.Integration.execute", Mock(return_value=False)
+        "admin.integrations.models.Integration.execute",
+        Mock(return_value=(False, "secret key is invalid")),
     ):
         response = client.post(
             url,
@@ -1628,7 +1629,7 @@ def test_new_hire_access_per_integration_post(
         assert "Account could not be created" in response.content.decode()
 
     with patch(
-        "admin.integrations.models.Integration.execute", Mock(return_value=True)
+        "admin.integrations.models.Integration.execute", Mock(return_value=(True, None))
     ):
         response = client.post(
             url,

--- a/back/users/templates/admin_base.html
+++ b/back/users/templates/admin_base.html
@@ -169,7 +169,7 @@
         <div class="page-body">
           <div class="container-xl">
             {% for message in messages %}
-            <div class="alert alert-success">
+            <div class="alert alert-{% if message.tags == 'error' %}danger{% else %}success{% endif %}">
               <p{% if message.tags %} class="{{ message.tags }}"{% endif %}>{{ message }}</p>
             </div>
             {% endfor %}

--- a/back/users/templates/login.html
+++ b/back/users/templates/login.html
@@ -5,7 +5,7 @@
 {% block content %}
 <form class="card card-md" method="post">
   {% for message in messages %}
-  <div class="alert alert-success">
+  <div class="alert alert-{% if message.tags == 'error' %}danger{% else %}success{% endif %}">
     <p{% if message.tags %} class="{{ message.tags }}"{% endif %}>{{ message }}</p>
   </div>
   {% endfor %}


### PR DESCRIPTION
We now get a good error message when something would fail in the integrations part:

![image](https://github.com/chiefonboarding/ChiefOnboarding/assets/1939656/4f10a8c7-182f-4093-ab35-0b3034d15081)

Secret values get replaced to avoid accidental exposure of keys/secrets.

This will need a revamp at some point (maybe a separate page for errors?). If we get HTML back, then it would quickly fill up the page. Most apis will return an error in JSON though and not HTML.