### PR TITLE
Update object storage docs

### DIFF
--- a/back/back/settings.py
+++ b/back/back/settings.py
@@ -294,7 +294,7 @@ AWS_S3_ENDPOINT_URL = env(
 AWS_ACCESS_KEY_ID = env("AWS_ACCESS_KEY_ID", default="")
 AWS_SECRET_ACCESS_KEY = env("AWS_SECRET_ACCESS_KEY", default="")
 AWS_STORAGE_BUCKET_NAME = env("AWS_STORAGE_BUCKET_NAME", default="")
-# fall back for old environment variable, AWS_DEFAULT_REGION should be prefered
+# fallback for old environment variable, AWS_DEFAULT_REGION should be prefered
 AWS_REGION = env("AWS_REGION", default="eu-west-1")
 AWS_DEFAULT_REGION = env("AWS_DEFAULT_REGION", default=AWS_REGION)
 

--- a/back/back/settings.py
+++ b/back/back/settings.py
@@ -294,7 +294,9 @@ AWS_S3_ENDPOINT_URL = env(
 AWS_ACCESS_KEY_ID = env("AWS_ACCESS_KEY_ID", default="")
 AWS_SECRET_ACCESS_KEY = env("AWS_SECRET_ACCESS_KEY", default="")
 AWS_STORAGE_BUCKET_NAME = env("AWS_STORAGE_BUCKET_NAME", default="")
+# fall back for old environment variable, AWS_DEFAULT_REGION should be prefered
 AWS_REGION = env("AWS_REGION", default="eu-west-1")
+AWS_DEFAULT_REGION = env("AWS_DEFAULT_REGION", default=AWS_REGION)
 
 if env.str("BASE_URL", "") == "":
     BASE_URL = "https://" + ALLOWED_HOSTS[0]

--- a/back/misc/s3.py
+++ b/back/misc/s3.py
@@ -7,7 +7,7 @@ class S3:
     def __init__(self):
         self.client = boto3.client(
             "s3",
-            settings.AWS_REGION,
+            settings.AWS_DEFAULT_REGION,
             endpoint_url=settings.AWS_S3_ENDPOINT_URL,
             config=Config(signature_version="s3v4"),
         )

--- a/docs/Deployment.md
+++ b/docs/Deployment.md
@@ -189,6 +189,10 @@ As of right now, your ChiefOnboarding instance will be up and running. Though, i
 ### Object storage (up/downloading files)
 You can use AWS S3 for this, but you are also free to use any other provider who provides the same API. For example: Wasabi, Vultr, Digital Ocean, or Fuga cloud.
 
+The instructions below will set everything up by using client/secret token. You can also use a profile/role if you prefer. Under the hood, ChiefOnboarding uses `boto3`, which means that it will search for credentials by itself as well. Please see the documentation for those boto3 environment variables here: https://boto3.amazonaws.com/v1/documentation/api/latest/guide/configuration.html
+
+Note that you might still need to set some of the environment variables below (such as the bucket).
+
 Here is a step-by-step for AWS:
 
 1. Go to [https://s3.console.aws.amazon.com/s3/home](https://s3.console.aws.amazon.com/s3/home) and click on 'Create bucket'.
@@ -243,7 +247,7 @@ AWS_S3_ENDPOINT_URL=https://s3.eu-west-1.amazonaws.com
 AWS_ACCESS_KEY_ID=AKIAXXXXXXXX
 AWS_SECRET_ACCESS_KEY=XXXXXXXXXXXXX
 AWS_STORAGE_BUCKET_NAME=bucket-name
-AWS_REGION=eu-west-1
+AWS_DEFAULT_REGION=eu-west-1
 ```
 
 If you want to use Minio (self-hosted), then you could use something like this as an example for both ChiefOnboarding and Minio:
@@ -280,7 +284,7 @@ services:
       - AWS_ACCESS_KEY_ID=chief
       - AWS_SECRET_ACCESS_KEY=chiefpass
       - AWS_STORAGE_BUCKET_NAME=test-bucket
-      - AWS_REGION=us-east-1
+      - AWS_DEFAULT_REGION=us-east-1
     depends_on:                                      
       - db                                                                                                         
     networks:


### PR DESCRIPTION
- Update the documentation to show that role/profile authentication is possible as well.
- Change `AWS_REGION` -> `AWS_DEFAULT_REGION` (with fallback, so it's not a breaking change)