### PR TITLE
Set default csrf trusted origin to fix docker deployment

### DIFF
--- a/back/back/settings.py
+++ b/back/back/settings.py
@@ -39,10 +39,21 @@ else:
         env("ALLOWED_HOST", default="0.0.0.0"),
     ]
 
-CSRF_TRUSTED_ORIGINS = env.list("CSRF_TRUSTED_ORIGINS", default=[])
-
 if DEBUG:
     ALLOWED_HOSTS = ["*"]
+
+
+if env.str("BASE_URL", "") == "":
+    BASE_URL = "https://" + ALLOWED_HOSTS[0]
+else:
+    BASE_URL = env("BASE_URL")
+
+CSRF_TRUSTED_ORIGINS = env.list(
+    "CSRF_TRUSTED_ORIGINS",
+    default=[
+        BASE_URL,
+    ],
+)
 
 INSTALLED_APPS = [
     "django.contrib.auth",
@@ -293,11 +304,6 @@ AWS_STORAGE_BUCKET_NAME = env("AWS_STORAGE_BUCKET_NAME", default="")
 # fallback for old environment variable, AWS_DEFAULT_REGION should be prefered
 AWS_REGION = env("AWS_REGION", default="eu-west-1")
 AWS_DEFAULT_REGION = env("AWS_DEFAULT_REGION", default=AWS_REGION)
-
-if env.str("BASE_URL", "") == "":
-    BASE_URL = "https://" + ALLOWED_HOSTS[0]
-else:
-    BASE_URL = env("BASE_URL")
 
 # Twilio
 TWILIO_FROM_NUMBER = env("TWILIO_FROM_NUMBER", default="")


### PR DESCRIPTION
Fixes docker deployments which would use an internal url instead as the default

fixes #319