### PR TITLE
Fix unknown mark warning from pytest

### DIFF
--- a/back/pytest.ini
+++ b/back/pytest.ini
@@ -1,3 +1,5 @@
 [pytest]
 DJANGO_SETTINGS_MODULE = back.settings
 python_files = tests.py test_*.py *_tests.py
+markers =
+    no_run_around_tests: let's you run tests without setting up an org automatically


### PR DESCRIPTION
Fixes:
```
organization/tests.py:218
  /app/organization/tests.py:218: PytestUnknownMarkWarning: Unknown pytest.mark.no_run_around_tests - is this a typo?  You can register custom marks to avoid this warning - for details, see https://docs.pytest.org/en/stable/how-to/
mark.html                                                                                                                                                                                                                              
    @pytest.mark.no_run_around_tests 
```