### PR TITLE
Fix button poorly visible on setup

### DIFF
--- a/back/organization/templates/initial_setup.html
+++ b/back/organization/templates/initial_setup.html
@@ -1,6 +1,15 @@
 {% extends 'no_login_base.html' %}
 {% load i18n static %}
 {% load crispy_forms_tags %}
+{% block extra_head %}
+<style>
+  /* the button would be blank without this as the org (which defines the color) is not created yet */
+  .btn-primary, .btn-outline-primary, .btn-ghost-primary, .btn-primary:hover, .btn-outline-primary:hover, .btn-ghost-primary:hover {
+    --tblr-btn-color: 153, 131, 92;
+    --tblr-btn-color-darker: 153, 131, 92;
+  }
+</style>
+{% endblock %}
 
 {% block content %}
 <form class="card card-md" method="post">

--- a/back/users/templates/no_login_base.html
+++ b/back/users/templates/no_login_base.html
@@ -26,6 +26,7 @@
         outline: 0;
         box-shadow: 0 0 0 0.25rem rgba({{ org.base_color_rgb }}, 0.25); }
     </style>
+    {% block extra_head %}{% endblock %}
   </head>
   <body class="antialiased border-top-wide border-primary d-flex flex-column">
     <div class="page page-center">


### PR DESCRIPTION
From this:
![image](https://github.com/chiefonboarding/ChiefOnboarding/assets/1939656/421da2b5-3b39-4a98-b80a-71b002b3a714)

To this:
![image](https://github.com/chiefonboarding/ChiefOnboarding/assets/1939656/ecd05f74-8df9-4366-8473-1d650775d53c)

Color is hardcoded to the default (when creating the org). Hard coding is fine in this case as the page will only show once when setting up.