### PR TITLE
convert email to lowercase

### DIFF
--- a/back/user_auth/views.py
+++ b/back/user_auth/views.py
@@ -280,7 +280,7 @@ class OIDCLoginView(View):
     def authenticate_user(self, user_info):
         if "email" in user_info:
             user, created = get_user_model().objects.get_or_create(
-                email=user_info["email"]
+                email=user_info["email"].lower()
             )
             if created:
                 user = self.__sync_user(user_info)


### PR DESCRIPTION
Due to bug #337 where SSO is doing lookup by email in case sensitive way (when the DB is always lowercase), I added the lower function to match emails by lowercase as well.
No test was written, just run isort, black and flake8