### PR TITLE
Heroku change dyno to basic

### DIFF
--- a/app.json
+++ b/app.json
@@ -8,11 +8,11 @@
   "formation": {
     "web": {
       "quantity": 1,
-      "size": "hobby"
+      "size": "basic"
     },
     "worker": {
       "quantity": 1,
-      "size": "hobby"
+      "size": "basic"
     }
   },
   "image": "heroku/python",


### PR DESCRIPTION
`hobby` is not available anymore, so we are switching to basic (the eco ones sleep, which is not recommended for the worker).