### PR TITLE
Fix potential incorrect assignment of to do condition

### DIFF
--- a/back/admin/sequences/models.py
+++ b/back/admin/sequences/models.py
@@ -49,10 +49,10 @@ class Sequence(models.Model):
         return self
 
     def assign_to_user(self, user):
-        user_condition = None
-
         # adding conditions
         for sequence_condition in self.conditions.all():
+            user_condition = None
+
             # Check what kind of condition it is
             if sequence_condition.condition_type in [
                 Condition.Type.BEFORE,


### PR DESCRIPTION
In some cases it could happen that conditions got merged into an incorrect block. This could only happen when there were already overlapping to do conditions assigned to a new hire.