### PR TITLE
Make saving json from response fail safe

### DIFF
--- a/back/admin/integrations/models.py
+++ b/back/admin/integrations/models.py
@@ -422,9 +422,9 @@ class Integration(models.Model):
                 self.params["files"][save_as_file] = io.BytesIO(response.content)
 
             # save json response temporarily to be reused in other parts
-            if save_as_file is None and not isinstance(response, str):
+            try:
                 self.params["responses"].append(response.json())
-            else:
+            except:  # noqa E722
                 # if we save a file, then just append an empty dict
                 self.params["responses"].append({})
 


### PR DESCRIPTION
It would sometimes still fail if the "json" function was not in the response. This will catch everything and just fall back to an empty dict.