### PR TITLE
Fix showing integrations on new hire page

### DIFF
--- a/back/admin/people/new_hire_views.py
+++ b/back/admin/people/new_hire_views.py
@@ -323,11 +323,13 @@ class NewHireSequenceView(LoginRequiredMixin, IsAdminOrNewHireManagerMixin, Deta
                     condition_type=Condition.Type.AFTER, days__gte=new_hire.workday
                 )
                 | conditions.filter(condition_type=Condition.Type.TODO)
+                | conditions.filter(condition_type=Condition.Type.ADMIN_TASK)
             )
             .annotate(
                 days_order=Case(
                     When(condition_type=Condition.Type.BEFORE, then=F("days") * -1),
                     When(condition_type=Condition.Type.TODO, then=99999),
+                    When(condition_type=Condition.Type.ADMIN_TASK, then=99999),
                     default=F("days"),
                     output_field=IntegerField(),
                 )
@@ -342,6 +344,9 @@ class NewHireSequenceView(LoginRequiredMixin, IsAdminOrNewHireManagerMixin, Deta
         context["completed_todos"] = ToDoUser.objects.filter(
             user=new_hire, completed=True
         ).values_list("to_do__pk", flat=True)
+        context["completed_admin_tasks"] = AdminTask.objects.filter(
+            new_hire=new_hire, completed=True
+        ).values_list("based_on__pk", flat=True)
         return context
 
 

--- a/back/admin/people/templates/new_hire_detail.html
+++ b/back/admin/people/templates/new_hire_detail.html
@@ -79,9 +79,18 @@
                 <div class="list-timeline-content pt-0" style="margin-top: -5px">
                   <div class="card">
                     <div class="card-header">
-                      {% if condition.condition_type != 1 %}
+                      {% if condition.condition_type == 0 or condition.condition_type == 2 %}
                       <h4 class="card-title">{{ condition|new_hire_trigger_date:object }} {% trans "at" %} {{ condition.time }}</h4>
-                      {% else %}
+                      {% elif condition.condition_type == 4 %}
+                      <h4 class="card-title">
+                        {% trans "When these admin tasks are completed:" %}
+                        <div id="div_id_condition_to_do">
+                          {% for to_do in condition.condition_admin_tasks.all %}
+                          <span class="badge {% if to_do.id in completed_admin_tasks %}bg-green-lt{% else %}bg-blue-lt{% endif %} mt-1">{{ to_do.name }}</span>
+                          {% endfor %}
+                        </div>
+                      </h4>
+                      {% elif condition.condition_type == 1 %}
                       <h4 class="card-title">
                         {% trans "When these tasks are completed:" %}
                         <div id="div_id_condition_to_do">
@@ -125,9 +134,12 @@
                       {% endfor %}
 
                       {# FOR ADMINS #}
-                      {% if condition.external_admin|length or condition.admin_tasks.all|length %}
+                      {% if condition.external_admin|length or condition.admin_tasks.all|length or condition.integration_configs.all|length %}
                       <span class="badge bg-orange mb-2">{% translate "admins" %}</span>
                       {% endif %}
+                      {% for item in condition.integration_configs.all %}
+                        {% include '_condition_line_item.html' with type='integrationconfig' provision_created=1 %}
+                      {% endfor %}
                       {% for item in condition.admin_tasks.all %}
                         {% include '_condition_line_item.html' with type='admintask' read_only=True %}
                       {% endfor %}


### PR DESCRIPTION
Forgot to implement a way to show the integrations and the admin tasks on the new hire page. This fixes that.