### PR TITLE
Add check for manager and buddy assigned to user where required

### DIFF
--- a/back/admin/integrations/models.py
+++ b/back/admin/integrations/models.py
@@ -41,7 +41,7 @@ from admin.integrations.utils import get_value_from_notation
 from misc.fernet_fields import EncryptedTextField
 from misc.fields import EncryptedJSONField
 from organization.models import Notification
-from organization.utils import send_email_with_notification
+from organization.utils import has_manager_or_buddy_tags, send_email_with_notification
 
 
 class IntegrationManager(models.Manager):
@@ -134,6 +134,11 @@ class Integration(models.Model):
     @property
     def schedule_name(self):
         return f"User sync for integration: {self.id}"
+
+    @property
+    def requires_assigned_manager_or_buddy(self):
+        # returns manager, buddy
+        return has_manager_or_buddy_tags(self.manifest)
 
     def clean(self):
         if not self.manifest or self.skip_user_provisioning:

--- a/back/admin/people/templates/_new_hire_settings_menu.html
+++ b/back/admin/people/templates/_new_hire_settings_menu.html
@@ -1,4 +1,9 @@
 {% load i18n %}
+{% if object.requires_manager_or_buddy.buddy or object.requires_manager_or_buddy.manager %}
+  <a href="{% url 'people:new_hire_profile' object.id %}" aria-label="{% if buddy and manager %}{% translate "You have assigned items to this user that require a manager and a buddy. Please assign one." %}{% elif buddy %}{% translate "You have assigned items to this user that require a buddy. Please assign one." %}{% else %}{% translate "You have assigned items to this user that require a manager. Please assign one." %}{% endif %}" data-microtip-position="top" role="tooltip" class="btn">
+    <svg xmlns="http://www.w3.org/2000/svg" class="icon icon-tabler icon-tabler-alert-triangle" style="margin-right: 0px" width="24" height="24" viewBox="0 0 24 24" stroke-width="2" stroke="indianred" fill="none" stroke-linecap="round" stroke-linejoin="round"><path stroke="none" d="M0 0h24v24H0z" fill="none"/><path d="M12 9v4" /><path d="M10.363 3.591l-8.106 13.534a1.914 1.914 0 0 0 1.636 2.871h16.214a1.914 1.914 0 0 0 1.636 -2.87l-8.106 -13.536a1.914 1.914 0 0 0 -3.274 0z" /><path d="M12 16h.01" /></svg>
+  </a>
+{% endif %}
 <div class="dropdown">
   <button class="btn btn-white dropdown-toggle" type="button" id="dropdownMenuButton1" data-bs-toggle="dropdown" aria-expanded="false">
     {% translate "Settings" %}

--- a/back/admin/sequences/models.py
+++ b/back/admin/sequences/models.py
@@ -331,6 +331,14 @@ class ExternalMessage(ContentMixin, models.Model):
         if self.is_text_message:
             return render_to_string("_text_icon.html")
 
+    @property
+    def requires_assigned_manager_or_buddy(self):
+        # returns manager, buddy
+        return (
+            self.person_type == ExternalMessage.PersonType.MANAGER,
+            self.person_type == ExternalMessage.PersonType.BUDDY,
+        )
+
     def duplicate(self, change_name=False):
         self.pk = None
         self.save()
@@ -501,6 +509,14 @@ class PendingAdminTask(models.Model):
     def __str__(self):
         return self.name
 
+    @property
+    def requires_assigned_manager_or_buddy(self):
+        # returns manager, buddy
+        return (
+            self.person_type == PendingAdminTask.PersonType.MANAGER,
+            self.person_type == PendingAdminTask.PersonType.BUDDY,
+        )
+
     def get_user(self, new_hire):
         if self.person_type == PendingAdminTask.PersonType.NEWHIRE:
             return new_hire
@@ -566,6 +582,14 @@ class IntegrationConfig(models.Model):
         null=True,
         blank=True,
     )
+
+    @property
+    def requires_assigned_manager_or_buddy(self):
+        # returns manager, buddy
+        return (
+            self.person_type == IntegrationConfig.PersonType.MANAGER,
+            self.person_type == IntegrationConfig.PersonType.BUDDY,
+        )
 
     @property
     def name(self):

--- a/back/organization/models.py
+++ b/back/organization/models.py
@@ -261,6 +261,14 @@ class BaseItem(ContentMixin, models.Model):
     class Meta:
         abstract = True
 
+    @property
+    def requires_assigned_manager_or_buddy(self):
+        from organization.utils import has_manager_or_buddy_tags
+
+        # returns manager, buddy
+        content = getattr(self, "content", None)
+        return has_manager_or_buddy_tags(content)
+
     def save(self, *args, **kwargs):
         if self.tags is None:
             self.tags = []

--- a/back/organization/utils.py
+++ b/back/organization/utils.py
@@ -1,3 +1,4 @@
+import json
 import smtplib
 
 from anymail.exceptions import (
@@ -57,3 +58,20 @@ def send_email_with_notification(
             created_for=created_for,
             extra_text=subject,
         )
+
+
+def has_manager_or_buddy_tags(content):
+    if content is None:
+        return False, False
+
+    # convert to string and then remove all spaces, so we can easily match
+    content_str = json.dumps(content)
+    content_str_no_spaces = "".join(content_str.split())
+
+    manager_tags = ["{{manager}}", "{{manager_email}}"]
+    buddy_tags = ["{{buddy}}", "{{buddy_email}}"]
+
+    requires_manager = any([tag in content_str_no_spaces for tag in manager_tags])
+    requires_buddy = any([tag in content_str_no_spaces for tag in buddy_tags])
+
+    return requires_manager, requires_buddy

--- a/back/organization/utils.py
+++ b/back/organization/utils.py
@@ -60,12 +60,12 @@ def send_email_with_notification(
         )
 
 
-def has_manager_or_buddy_tags(content):
-    if content is None:
+def has_manager_or_buddy_tags(content_json):
+    if content_json is None:
         return False, False
 
     # convert to string and then remove all spaces, so we can easily match
-    content_str = json.dumps(content)
+    content_str = json.dumps(content_json)
     content_str_no_spaces = "".join(content_str.split())
 
     manager_tags = ["{{manager}}", "{{manager_email}}"]

--- a/back/users/models.py
+++ b/back/users/models.py
@@ -345,7 +345,9 @@ class User(AbstractBaseUser):
                         requires_buddy = True
 
                     # stop if we either have a user or if assigned user is required
-                    if (requires_manager or has_manager) and (requires_buddy or has_buddy):
+                    if (requires_manager or has_manager) and (
+                        requires_buddy or has_buddy
+                    ):
                         break
 
         return {"manager": requires_manager, "buddy": requires_buddy}

--- a/back/users/models.py
+++ b/back/users/models.py
@@ -298,6 +298,11 @@ class User(AbstractBaseUser):
 
     @property
     def requires_manager_or_buddy(self):
+        has_buddy = self.buddy is not None
+        has_manager = self.manager is not None
+        # end early if both are already filled
+        if has_buddy and has_manager:
+            return False, False
         # not all items have to be checked. Introductions for example, doesn't have a
         # content field.
         to_check = [
@@ -334,13 +339,13 @@ class User(AbstractBaseUser):
                             item_requires_buddy,
                         ) = i.requires_assigned_manager_or_buddy
 
-                    if item_requires_manager:
+                    if item_requires_manager and not has_manager:
                         requires_manager = True
-                    if item_requires_buddy:
+                    if item_requires_buddy and not has_buddy:
                         requires_buddy = True
 
-                    # stop if both are required, no need to go further
-                    if requires_manager and requires_buddy:
+                    # stop if we either have a user or if assigned user is required
+                    if (requires_manager or has_manager) and (requires_buddy or has_buddy):
                         break
 
         return {"manager": requires_manager, "buddy": requires_buddy}

--- a/back/users/models.py
+++ b/back/users/models.py
@@ -296,10 +296,9 @@ class User(AbstractBaseUser):
             if item["id"] not in self.extra_fields.keys()
         ]
 
-    @property
     def requires_manager_or_buddy(self):
-        has_buddy = self.buddy is not None
-        has_manager = self.manager is not None
+        has_buddy = self.buddy_id is not None
+        has_manager = self.manager_id is not None
         # end early if both are already filled
         if has_buddy and has_manager:
             return {"manager": False, "buddy": False}

--- a/back/users/models.py
+++ b/back/users/models.py
@@ -302,7 +302,7 @@ class User(AbstractBaseUser):
         has_manager = self.manager is not None
         # end early if both are already filled
         if has_buddy and has_manager:
-            return False, False
+            return {"manager": False, "buddy": False}
         # not all items have to be checked. Introductions for example, doesn't have a
         # content field.
         to_check = [

--- a/back/users/models.py
+++ b/back/users/models.py
@@ -16,6 +16,7 @@ from django.utils.translation import gettext_lazy as _
 from admin.appointments.models import Appointment
 from admin.badges.models import Badge
 from admin.hardware.models import Hardware
+from admin.integrations.models import Integration
 from admin.introductions.models import Introduction
 from admin.preboarding.models import Preboarding
 from admin.resources.models import CourseAnswer, Resource
@@ -295,6 +296,55 @@ class User(AbstractBaseUser):
             if item["id"] not in self.extra_fields.keys()
         ]
 
+    @property
+    def requires_manager_or_buddy(self):
+        # not all items have to be checked. Introductions for example, doesn't have a
+        # content field.
+        to_check = [
+            "to_do",
+            "resources",
+            "appointments",
+            "badges",
+            "hardware",
+            "external_messages",
+            "admin_tasks",
+            "preboarding",
+            "integration_configs",
+        ]
+        requires_manager = False
+        requires_buddy = False
+        for item in self.conditions.prefetched().prefetch_related(
+            "integration_configs__integration"
+        ):
+            for field in to_check:
+                condition_attribute = getattr(item, field)
+                for i in condition_attribute.all():
+                    if (
+                        field == "integration_configs"
+                        and i.integration.manifest_type
+                        == Integration.ManifestType.WEBHOOK
+                    ):
+                        (
+                            item_requires_manager,
+                            item_requires_buddy,
+                        ) = i.integration.requires_assigned_manager_or_buddy
+                    else:
+                        (
+                            item_requires_manager,
+                            item_requires_buddy,
+                        ) = i.requires_assigned_manager_or_buddy
+
+                    if item_requires_manager:
+                        requires_manager = True
+                    if item_requires_buddy:
+                        requires_buddy = True
+
+                    # stop if both are required, no need to go further
+                    if requires_manager and requires_buddy:
+                        break
+
+        return {"manager": requires_manager, "buddy": requires_buddy}
+
     def update_progress(self):
         all_to_do_ids = list(
             self.conditions.values_list("to_do__id", flat=True)
@@ -485,8 +535,6 @@ class User(AbstractBaseUser):
         return ", ".join(all_access)
 
     def check_integration_access(self):
-        from admin.integrations.models import Integration
-
         items = {}
         for integration_user in IntegrationUser.objects.filter(user=self):
             items[integration_user.integration.name] = not integration_user.revoked

--- a/back/users/tests.py
+++ b/back/users/tests.py
@@ -316,6 +316,7 @@ def test_check_for_buddy_manager_tags(
     integration_config_factory,
     manual_user_provision_integration_factory,
     custom_integration_factory,
+    employee_factory
 ):
     new_hire = new_hire_factory()
     integration = manual_user_provision_integration_factory()
@@ -367,6 +368,23 @@ def test_check_for_buddy_manager_tags(
 
     # none of the items have a buddy or manager tag, so should return false
     assert {"manager": True, "buddy": False} == new_hire.requires_manager_or_buddy
+
+    # manager is assigned
+    new_hire.manager = employee_factory()
+    new_hire.save()
+
+    assert {"manager": False, "buddy": False} == new_hire.requires_manager_or_buddy
+
+    # require buddy too now, but assign a buddy as well now
+    integration = custom_integration_factory(
+        manifest={"test": {"test2": "{{manager_email}}, {{ buddy_email }}"}}
+    )
+    integration.save()
+    new_hire.buddy = employee_factory()
+    new_hire.save()
+
+    # ends early as both are already assigned
+    assert {"manager": False, "buddy": False} == new_hire.requires_manager_or_buddy
 
 
 @pytest.mark.django_db

--- a/back/users/tests.py
+++ b/back/users/tests.py
@@ -335,19 +335,19 @@ def test_check_for_buddy_manager_tags(
     new_hire.conditions.add(condition)
 
     # none of the items have a buddy or manager tag, so should return false
-    assert {"manager": False, "buddy": False} == new_hire.requires_manager_or_buddy
+    assert {"manager": False, "buddy": False} == new_hire.requires_manager_or_buddy()
 
     to_do1.content = {"test": "test {{ manager }} "}
     to_do1.save()
 
     # has manager tag now and not buddy
-    assert {"manager": True, "buddy": False} == new_hire.requires_manager_or_buddy
+    assert {"manager": True, "buddy": False} == new_hire.requires_manager_or_buddy()
 
     integration_config1.person_type = IntegrationConfig.PersonType.BUDDY
     integration_config1.save()
 
     # has manager tag now and buddy tag
-    assert {"manager": True, "buddy": True} == new_hire.requires_manager_or_buddy
+    assert {"manager": True, "buddy": True} == new_hire.requires_manager_or_buddy()
 
     # reset both
     integration_config1.person_type = None
@@ -357,7 +357,7 @@ def test_check_for_buddy_manager_tags(
     to_do1.save()
 
     # none of the items have a buddy or manager tag, so should return false
-    assert {"manager": False, "buddy": False} == new_hire.requires_manager_or_buddy
+    assert {"manager": False, "buddy": False} == new_hire.requires_manager_or_buddy()
 
     integration = custom_integration_factory(
         manifest={"test": {"test2": "{{manager_email}}"}}
@@ -367,13 +367,13 @@ def test_check_for_buddy_manager_tags(
     condition.integration_configs.add(integration_config2)
 
     # none of the items have a buddy or manager tag, so should return false
-    assert {"manager": True, "buddy": False} == new_hire.requires_manager_or_buddy
+    assert {"manager": True, "buddy": False} == new_hire.requires_manager_or_buddy()
 
     # manager is assigned
     new_hire.manager = employee_factory()
     new_hire.save()
 
-    assert {"manager": False, "buddy": False} == new_hire.requires_manager_or_buddy
+    assert {"manager": False, "buddy": False} == new_hire.requires_manager_or_buddy()
 
     # require buddy too now, but assign a buddy as well now
     integration = custom_integration_factory(
@@ -384,7 +384,7 @@ def test_check_for_buddy_manager_tags(
     new_hire.save()
 
     # ends early as both are already assigned
-    assert {"manager": False, "buddy": False} == new_hire.requires_manager_or_buddy
+    assert {"manager": False, "buddy": False} == new_hire.requires_manager_or_buddy()
 
 
 @pytest.mark.django_db

--- a/back/users/tests.py
+++ b/back/users/tests.py
@@ -5,6 +5,7 @@ import pytest
 from django.contrib.auth import get_user_model
 from freezegun import freeze_time
 
+from admin.sequences.models import IntegrationConfig
 from organization.models import Organization
 from users.tasks import hourly_check_for_new_hire_send_credentials
 
@@ -303,6 +304,69 @@ def test_new_hire_manager(new_hire_factory):
     should_intro.save()
 
     assert User.new_hires.to_introduce().count() == 2
+
+
+@pytest.mark.django_db
+def test_check_for_buddy_manager_tags(
+    new_hire_factory,
+    condition_to_do_factory,
+    to_do_factory,
+    resource_factory,
+    hardware_factory,
+    integration_config_factory,
+    manual_user_provision_integration_factory,
+    custom_integration_factory,
+):
+    new_hire = new_hire_factory()
+    integration = manual_user_provision_integration_factory()
+    integration_config1 = integration_config_factory(integration=integration)
+    to_do1 = to_do_factory()
+    to_do2 = to_do_factory()
+    resource1 = resource_factory()
+    hardware1 = hardware_factory()
+
+    condition = condition_to_do_factory()
+    condition.to_do.add(to_do1, to_do2)
+    condition.resources.add(resource1)
+    condition.hardware.add(hardware1)
+    condition.integration_configs.add(integration_config1)
+
+    new_hire.conditions.add(condition)
+
+    # none of the items have a buddy or manager tag, so should return false
+    assert {"manager": False, "buddy": False} == new_hire.requires_manager_or_buddy
+
+    to_do1.content = {"test": "test {{ manager }} "}
+    to_do1.save()
+
+    # has manager tag now and not buddy
+    assert {"manager": True, "buddy": False} == new_hire.requires_manager_or_buddy
+
+    integration_config1.person_type = IntegrationConfig.PersonType.BUDDY
+    integration_config1.save()
+
+    # has manager tag now and buddy tag
+    assert {"manager": True, "buddy": True} == new_hire.requires_manager_or_buddy
+
+    # reset both
+    integration_config1.person_type = None
+    integration_config1.save()
+
+    to_do1.content = {}
+    to_do1.save()
+
+    # none of the items have a buddy or manager tag, so should return false
+    assert {"manager": False, "buddy": False} == new_hire.requires_manager_or_buddy
+
+    integration = custom_integration_factory(
+        manifest={"test": {"test2": "{{manager_email}}"}}
+    )
+
+    integration_config2 = integration_config_factory(integration=integration)
+    condition.integration_configs.add(integration_config2)
+
+    # none of the items have a buddy or manager tag, so should return false
+    assert {"manager": True, "buddy": False} == new_hire.requires_manager_or_buddy
 
 
 @pytest.mark.django_db

--- a/back/users/tests.py
+++ b/back/users/tests.py
@@ -316,7 +316,7 @@ def test_check_for_buddy_manager_tags(
     integration_config_factory,
     manual_user_provision_integration_factory,
     custom_integration_factory,
-    employee_factory
+    employee_factory,
 ):
     new_hire = new_hire_factory()
     integration = manual_user_provision_integration_factory()


### PR DESCRIPTION
New hires can have a manager/buddy assigned to them. These can then be used in content boxes (by using `{{ manager }}` or `{{ manager_email }}` or similar ones for a buddy) or they can be used for admin tasks or external messages in sequences to assign tasks to or send messages to.

When a new hire gets assigned a sequences that has those references and the new hire does not have a manager, then those will (silently) fail. In the case of content, it will just display nothing. For admin tasks, this will fail the creation of an admin task. 

In most cases, the manager/buddy will be filled for most people, so this will likely not happen often. Though, as a precaution, it will now display a button if that's the case (which leads to the profile page to update the new hire):

![image](https://github.com/chiefonboarding/ChiefOnboarding/assets/1939656/2c005557-4a73-4cc8-8720-5e6926c5e02b)
