### PR TITLE
Disable todo in offboarding sequences

### DIFF
--- a/back/admin/sequences/templates/_sequence_templates_list.html
+++ b/back/admin/sequences/templates/_sequence_templates_list.html
@@ -1,9 +1,11 @@
 {% load i18n %}
 <div class="card-body select-template">
   <h3>{% translate "Templates" %} <div style="display: inline-block; margin-left: 10px; bottom: 2px;" aria-label="{% translate "Drag and drop the items below into the sequence blocks to add them" %}" data-microtip-position="top" role="tooltip" > <svg xmlns="http://www.w3.org/2000/svg" style="width: 16px; height: 16px;"  class="icon icon-tabler icon-tabler-info-square-rounded" width="24" height="24" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round"><path stroke="none" d="M0 0h24v24H0z" fill="none"/><path d="M12 9h.01" /><path d="M11 12h1v4h1" /><path d="M12 3c7.2 0 9 1.8 9 9s-1.8 9 -9 9s-9 -1.8 -9 -9s1.8 -9 9 -9z" /></svg></div> </h3>
+  {% if sequence.is_onboarding %}
   <button aria-label="{% translate "Todo items" %}" data-microtip-position="top" role="tooltip" hx-get="{% url 'sequences:template_list' sequence.id %}?type=todo" class="btn btn-{% if active == 'todo' %}primary{% else %}white{% endif %}" hx-target="#template-list" hx-indicator="#spinner">
     {% include '_todo_icon.html' %}
   </button>
+  {% endif %}
   <button aria-label="{% translate "Resources" %}" data-microtip-position="top" role="tooltip" hx-get="{% url 'sequences:template_list' sequence.id %}?type=resource" class="btn btn-{% if active == 'resource' %}primary{% else %}white{% endif %}" hx-target="#template-list" hx-indicator="#spinner">
     {% include '_resource_icon.html' %}
   </button>
@@ -69,7 +71,7 @@
 {% if active != 'integration' %}
 <div class="card-footer">
   <div>
-    <div class="row" draggable="true" style="cursor:grab" data-id="0" data-type="{{ active }}" 
+    <div class="row" draggable="true" style="cursor:grab" data-id="0" data-type="{{ active }}"
         aria-label="{% translate "Drag this unto a sequence block to create new item" %}" data-microtip-position="bottom" role="tooltip">
       <div class="col-auto align-self-center">
         <div class="badge bg-primary"></div>


### PR DESCRIPTION
Todo is focussed on new hire (also based on the start date), so this is broken. Temporarily removing it.