### PR TITLE
Fix missing expiring key for integration builder

### DIFF
--- a/back/admin/integrations/views.py
+++ b/back/admin/integrations/views.py
@@ -352,7 +352,9 @@ class IntegrationTestView(LoginRequiredMixin, AdminPermMixin, View):
         # mock extra fields to user. DO NOT SAVE!
         extra_fields_dict = {item["key"]: item["value"] for item in extra_fields}
         user.extra_fields = extra_fields_dict
-        integration = Integration(manifest=manifest, extra_args=extra_args_dict, expiring=expiring)
+        integration = Integration(
+            manifest=manifest, extra_args=extra_args_dict, expiring=expiring
+        )
 
         if test_type == "form":
             form = integration.config_form()

--- a/back/admin/integrations/views.py
+++ b/back/admin/integrations/views.py
@@ -336,11 +336,14 @@ class IntegrationTestView(LoginRequiredMixin, AdminPermMixin, View):
                 return HttpResponse(f"Data of request {idx + 1} is not a valid json")
 
         extra_args_dict = {item["key"]: item["value"] for item in extra_args}
+        expiring = timezone.now()
 
         try:
-            extra_args_dict |= Integration.objects.get(
+            integration = Integration.objects.get(
                 id=request.POST.get("integration_id", -1)
-            ).extra_args
+            )
+            extra_args_dict |= integration.extra_args
+            expiring = integration.expiring
         except Integration.DoesNotExist:
             # don't use args from original manifest
             pass
@@ -348,7 +351,7 @@ class IntegrationTestView(LoginRequiredMixin, AdminPermMixin, View):
         # mock extra fields to user. DO NOT SAVE!
         extra_fields_dict = {item["key"]: item["value"] for item in extra_fields}
         user.extra_fields = extra_fields_dict
-        integration = Integration(manifest=manifest, extra_args=extra_args_dict)
+        integration = Integration(manifest=manifest, extra_args=extra_args_dict, expiring=expiring)
 
         if test_type == "form":
             form = integration.config_form()

--- a/back/admin/integrations/views.py
+++ b/back/admin/integrations/views.py
@@ -342,6 +342,7 @@ class IntegrationTestView(LoginRequiredMixin, AdminPermMixin, View):
             integration = Integration.objects.get(
                 id=request.POST.get("integration_id", -1)
             )
+            integration.renew_key()
             extra_args_dict |= integration.extra_args
             expiring = integration.expiring
         except Integration.DoesNotExist:


### PR DESCRIPTION
It couldn't compare the `integration.expiring` value as it creates a mock item (which doesn't get saved, so no new value was added).

This will first check if it needs to be renewed (and will renew if necessary), so this will be skipped on the actual test call.

The builder is still in beta, so forgoing adding tests right now.