### PR TITLE
Clean fields to not show secret values

### DIFF
--- a/back/admin/integrations/forms.py
+++ b/back/admin/integrations/forms.py
@@ -202,6 +202,9 @@ class IntegrationForm(forms.ModelForm):
 class IntegrationExtraArgsForm(forms.ModelForm):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
+        # TODO: allow secrets to be hidden from form instaed of hiding
+        # everything
+
         # initial_data = self.instance.extra_args
         for item in self.instance.manifest["initial_data_form"]:
             self.fields[item["id"]] = forms.CharField(

--- a/back/admin/integrations/forms.py
+++ b/back/admin/integrations/forms.py
@@ -202,14 +202,14 @@ class IntegrationForm(forms.ModelForm):
 class IntegrationExtraArgsForm(forms.ModelForm):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
-        initial_data = self.instance.extra_args
+        # initial_data = self.instance.extra_args
         for item in self.instance.manifest["initial_data_form"]:
             self.fields[item["id"]] = forms.CharField(
                 label=item["name"], help_text=item["description"]
             )
-            # Check if item was already saved - load data back in form
-            if item["id"] in initial_data:
-                self.fields[item["id"]].initial = initial_data[item["id"]]
+            # # Check if item was already saved - load data back in form
+            # if item["id"] in initial_data:
+            #     self.fields[item["id"]].initial = initial_data[item["id"]]
             # If field is secret field, then hide it - values are generated on the fly
             if "name" in item and item["name"] == "generate":
                 self.fields[item["id"]].required = False

--- a/back/admin/integrations/tests.py
+++ b/back/admin/integrations/tests.py
@@ -234,8 +234,8 @@ def test_integration_extra_args_form(
 
     response = client.get(url)
 
-    # Value that got added is now shown
-    assert "123" in response.content.decode()
+    # Value is not shown on update page
+    assert "123" not in response.content.decode()
 
 
 @pytest.mark.django_db


### PR DESCRIPTION
This removes the initial values to not show the secrets in the form to any user.