### PR TITLE
Show error when access can not be given

### DIFF
--- a/back/admin/people/access_views.py
+++ b/back/admin/people/access_views.py
@@ -200,6 +200,8 @@ class UserToggleAccessView(LoginRequiredMixin, IsAdminOrNewHireManagerMixin, Vie
         needs_user_info = integration.needs_user_info(user)
         if integration.user_exists(user):
             success, error = integration.revoke_user(user)
+            if error:
+                created = None
         else:
             success, error = integration.execute(user)
             created = True

--- a/back/admin/people/templates/_user_access_card.html
+++ b/back/admin/people/templates/_user_access_card.html
@@ -37,11 +37,11 @@
     </button>
     {% endif %}
     {% if not loading %}
+      {% if error %}
+      {% translate "Request failed with error: " %}<pre>{{ error }}</pre>
+      {% endif %}
       {% if active is None %}
         {% translate "Error when trying to reach service" %}
-        {% if error %}
-        {% translate "Failed with error: " %}<pre>{{ error }}</pre>
-        {% endif %}
       {% elif active %}
         <button class="btn btn-primary w-100">
           {% translate "Activated" %}

--- a/back/admin/people/templates/_user_access_card.html
+++ b/back/admin/people/templates/_user_access_card.html
@@ -39,6 +39,9 @@
     {% if not loading %}
       {% if active is None %}
         {% translate "Error when trying to reach service" %}
+        {% if error %}
+        {% translate "Failed with error: " %}<pre>{{ error }}</pre>
+        {% endif %}
       {% elif active %}
         <button class="btn btn-primary w-100">
           {% translate "Activated" %}

--- a/docs/Integrations.md
+++ b/docs/Integrations.md
@@ -63,6 +63,8 @@ Revoke is an option to revoke access of a user to a third party. If you add this
 
 This uses the same setup as the execute part below (but is limited to `url`, `data`, `method` and `headers`). It expects an array with requests in it.
 
+If you want to make the revoking fail when the status code of the request is not 2xx, then just add `fail_when_4xx_response_code` to the request and set it to `true`.
+
 
 ### Execute
 These requests will be ran when this integration gets triggered.


### PR DESCRIPTION
This was undocumented, but you can add `fail_when_4xx_response_code` to the revoke request to make it fail. 
It will now also show the error in the card when revoking/creating doesn't work.