### PR TITLE
Fix empty string being replaced

### DIFF
--- a/back/admin/integrations/models.py
+++ b/back/admin/integrations/models.py
@@ -825,7 +825,7 @@ class Integration(models.Model):
                         _("***Secret value for %(name)s***")
                         % {"name": name + "." + inner_name},
                     )
-            else:
+            elif value != "":
                 response = response.replace(
                     str(value), _("***Secret value for %(name)s***") % {"name": name}
                 )


### PR DESCRIPTION
In some cases, the password would turn up as an empty string and would therefore replace a lot of text with "Secret value for". This is now fixed.