### PR TITLE
Allow manually adding hardware to user

### DIFF
--- a/back/admin/people/templates/_toggle_button_hardware.html
+++ b/back/admin/people/templates/_toggle_button_hardware.html
@@ -1,0 +1,9 @@
+{% load i18n %}
+<div hx-post="{% url 'people:toggle_hardware' object.id template.id %}" hx-swap="outerHTML" classes="click btn-loading" class="btn {% if template in object.hardware.all %}btn-primary{% else %}btn-white{% endif %}" hx-indicator="#spinner-{{template.id}}">
+  <span class="requesting alsodisplay spinner-border spinner-border-sm me-2" id="spinner-{{template.id}}" role="status"></span>
+  {% if template in object.hardware.all %}
+    {% translate "Added" %}
+  {% else %}
+    {% translate "Add" %}
+  {% endif %}
+</div>

--- a/back/admin/people/templates/add_hardware.html
+++ b/back/admin/people/templates/add_hardware.html
@@ -1,0 +1,38 @@
+{% extends 'admin_base.html' %}
+{% load i18n %}
+
+{% block content %}
+<div class="col-12">
+
+  <div class="alert alert-info">
+    <p>{% translate "Changing hardware here will not send any messages to colleagues to send out or collect hardware. Use the sequences for that instead!"%}</p>
+  </div>
+
+  <div class="card">
+    <div class="table-responsive">
+      <table
+          class="table table-vcenter table-nowrap">
+        <thead>
+          <tr>
+            <th>{% translate "Name" %}</th>
+            <th>{% translate "Tags" %}</th>
+            <th></th>
+          </tr>
+        </thead>
+        <tbody>
+          {% for template in object_list %}
+          <tr>
+            <td>{{ template.name }}</td>
+            <td>{% for tag in template.tags %}<span class="badge bg-blue" style="margin-right: 10px">{{ tag }}</span>{% endfor %}</td>
+            <td class="text-end">
+              {% include "_toggle_button_hardware.html" %}
+            </td>
+          </tr>
+          {% endfor %}
+        </tbody>
+      </table>
+      {% include "_paginator.html" %}
+    </div>
+  </div>
+</div>
+{% endblock %}

--- a/back/admin/people/templates/colleague_update.html
+++ b/back/admin/people/templates/colleague_update.html
@@ -78,6 +78,11 @@
         </div>
         {% endfor %}
       </div>
+      <div class="card-footer">
+        <a href="{% url 'people:add_hardware' object.id %}" class="btn btn-primary">
+          {% translate "Change" %}
+        </a>
+      </div>
     </div>
   </div>
 </div>

--- a/back/admin/people/tests.py
+++ b/back/admin/people/tests.py
@@ -2780,7 +2780,6 @@ def test_employee_toggle_hardware(
     assert not employee1.resources.filter(id=hardware1.id).exists()
 
 
-
 @pytest.mark.django_db
 def test_visibility_import_employees_button(
     client,

--- a/back/admin/people/tests.py
+++ b/back/admin/people/tests.py
@@ -2727,6 +2727,61 @@ def test_employee_toggle_resources(
 
 
 @pytest.mark.django_db
+def test_employee_hardware(
+    client, django_user_model, employee_factory, hardware_factory
+):
+    client.force_login(
+        django_user_model.objects.create(role=get_user_model().Role.ADMIN)
+    )
+
+    employee1 = employee_factory()
+    hardware1 = hardware_factory()
+    hardware2 = hardware_factory(template=False)
+
+    url = reverse("people:add_hardware", args=[employee1.id])
+    response = client.get(url, follow=True)
+
+    assert hardware1.name in response.content.decode()
+    # Only show templates
+    assert hardware2.name not in response.content.decode()
+    assert "Added" not in response.content.decode()
+
+    # Add resource to user
+    employee1.hardware.add(hardware1)
+
+    response = client.get(url, follow=True)
+
+    # Has been added, so change button name
+    assert hardware2.name not in response.content.decode()
+    assert "Added" in response.content.decode()
+
+
+@pytest.mark.django_db
+def test_employee_toggle_hardware(
+    client, django_user_model, employee_factory, hardware_factory
+):
+    client.force_login(
+        django_user_model.objects.create(role=get_user_model().Role.ADMIN)
+    )
+
+    hardware1 = hardware_factory()
+    employee1 = employee_factory()
+
+    url = reverse("people:toggle_hardware", args=[employee1.id, hardware1.id])
+    response = client.post(url, follow=True)
+
+    assert "Added" in response.content.decode()
+    assert employee1.hardware.filter(id=hardware1.id).exists()
+
+    # Now remove the item
+    response = client.post(url, follow=True)
+
+    assert "Add" in response.content.decode()
+    assert not employee1.resources.filter(id=hardware1.id).exists()
+
+
+
+@pytest.mark.django_db
 def test_visibility_import_employees_button(
     client,
     django_user_model,

--- a/back/admin/people/urls.py
+++ b/back/admin/people/urls.py
@@ -169,6 +169,16 @@ urlpatterns = [
         name="add_resource",
     ),
     path(
+        "colleagues/<int:pk>/hardware/",
+        views.ColleagueHardwareView.as_view(),
+        name="add_hardware",
+    ),
+    path(
+        "colleagues/<int:pk>/hardware/<int:template_id>/",
+        views.ColleagueToggleHardwareView.as_view(),
+        name="toggle_hardware",
+    ),
+    path(
         "colleagues/<int:pk>/resource/<int:template_id>/",
         views.ColleagueToggleResourceView.as_view(),
         name="toggle_resource",

--- a/back/admin/people/views.py
+++ b/back/admin/people/views.py
@@ -14,6 +14,7 @@ from rest_framework import generics
 from rest_framework.authentication import SessionAuthentication
 
 from admin.admin_tasks.models import AdminTask
+from admin.hardware.models import Hardware
 from admin.integrations.exceptions import (
     DataIsNotJSONError,
     FailedPaginatedResponseError,
@@ -34,7 +35,6 @@ from users.mixins import (
     LoginRequiredMixin,
     ManagerPermMixin,
 )
-from admin.hardware.models import Hardware
 from users.models import ToDoUser
 
 from .forms import (
@@ -125,9 +125,7 @@ class ColleagueHardwareView(LoginRequiredMixin, ManagerPermMixin, DetailView):
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)
         user = context["object"]
-        context["title"] = _("Add new hardware for %(name)s") % {
-            "name": user.full_name
-        }
+        context["title"] = _("Add new hardware for %(name)s") % {"name": user.full_name}
         context["subtitle"] = _("Employee")
         context["object_list"] = Hardware.templates.all()
         return context

--- a/back/admin/people/views.py
+++ b/back/admin/people/views.py
@@ -34,6 +34,7 @@ from users.mixins import (
     LoginRequiredMixin,
     ManagerPermMixin,
 )
+from admin.hardware.models import Hardware
 from users.models import ToDoUser
 
 from .forms import (
@@ -115,6 +116,38 @@ class ColleagueUpdateView(
         context["title"] = new_hire.full_name
         context["subtitle"] = _("Employee")
         return context
+
+
+class ColleagueHardwareView(LoginRequiredMixin, ManagerPermMixin, DetailView):
+    template_name = "add_hardware.html"
+    model = get_user_model()
+
+    def get_context_data(self, **kwargs):
+        context = super().get_context_data(**kwargs)
+        user = context["object"]
+        context["title"] = _("Add new hardware for %(name)s") % {
+            "name": user.full_name
+        }
+        context["subtitle"] = _("Employee")
+        context["object_list"] = Hardware.templates.all()
+        return context
+
+
+class ColleagueToggleHardwareView(LoginRequiredMixin, ManagerPermMixin, View):
+    template_name = "_toggle_button_hardware.html"
+
+    def post(self, request, pk, template_id, *args, **kwargs):
+        context = {}
+        user = get_object_or_404(get_user_model(), id=pk)
+        hardware = get_object_or_404(Hardware, id=template_id, template=True)
+        if user.hardware.filter(id=hardware.id).exists():
+            user.hardware.remove(hardware)
+        else:
+            user.hardware.add(hardware)
+        context["id"] = id
+        context["template"] = hardware
+        context["object"] = user
+        return render(request, self.template_name, context)
 
 
 class ColleagueResourceView(LoginRequiredMixin, ManagerPermMixin, DetailView):


### PR DESCRIPTION
This adds a button on the colleagues detail page to manually add hardware to a user. This will not create to do items for any other colleagues to fulfill this. This is intended to be used for existing colleagues that already have hardware, which just need to be registered.