### PR TITLE
Move offboarding user exists check to backgroundworker

### DIFF
--- a/back/api/tasks.py
+++ b/back/api/tasks.py
@@ -1,0 +1,13 @@
+from admin.integrations.models import Integration
+from admin.sequences.models import Sequence
+
+
+def assign_offboarding_sequences(user, sequence_ids):
+    for integration in Integration.objects.filter(
+        manifest_type=Integration.ManifestType.WEBHOOK,
+        manifest__exists__isnull=False,
+    ):
+        integration.user_exists(user)
+
+    sequences = Sequence.offboarding.filter(id__in=sequence_ids)
+    user.add_sequences(sequences)

--- a/back/api/views.py
+++ b/back/api/views.py
@@ -4,8 +4,8 @@ from rest_framework import generics, status
 from rest_framework.response import Response
 from rest_framework.views import APIView
 
-from admin.integrations.models import Integration
 from admin.sequences.models import Sequence
+from api.tasks import assign_offboarding_sequences
 from organization.models import Notification, Organization
 from slack_bot.tasks import link_slack_users
 from users.emails import email_new_admin_cred
@@ -106,16 +106,11 @@ class UserOffboardingView(APIView):
         user.conditions.all().delete()
         user.termination_date = offboarding_date
         user.save()
-
-        # TODO: should become a background worker at some point
-        for integration in Integration.objects.filter(
-            manifest_type=Integration.ManifestType.WEBHOOK,
-            manifest__exists__isnull=False,
-        ):
-            integration.user_exists(user)
-
-        sequences = Sequence.offboarding.filter(id__in=sequence_ids)
-        user.add_sequences(sequences)
+        async_task(
+            assign_offboarding_sequences,
+            user,
+            sequence_ids,
+        )
         return Response(status=status.HTTP_200_OK)
 
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -88,5 +88,5 @@ It will return the full new hire object including the ID of the new hire.
 curl -X POST -H 'Content-Type: application/json' -H 'Accept: application/json' -H "Authorization: Token xxxxxxxxxxxxxxx" -d '{"termination_date":"2020-02-02", sequences: [1,4], user: 1 }' https://YOURDOMAIN/api/offboarding/
 ```
 
-Note: sequence ids can only be sequences for offboarding sequences, not onboarding sequences. 
+Note: sequence ids can only be sequences for offboarding sequences, not onboarding sequences. It might take a few minutes before the user's timeline is fully populated in the offboarding table.
 "user" is the user id, you can get it through the `https://YOURDOMAIN/api/employees/` call.


### PR DESCRIPTION
This moves the checking of accounts (which are needed for the sequences) to a background task, so it won't time out.